### PR TITLE
feat(types): Implement `Swizzle` functor and  `SwizzleLayout`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,8 @@
     "random": "cpp",
     "limits": "cpp",
     "semaphore": "cpp",
-    "regex": "cpp"
+    "regex": "cpp",
+    "tuple": "cpp"
   },
   "gotoSymbolStack.currentStackPosition": 0,
   "gotoSymbolStack.maxStackPosition": 0,

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -5,7 +5,6 @@
 #include "config.hpp"
 #include "cuda_utils.hpp"
 #include "traits/base.hpp"
-#include "types/swizzle.hpp"
 
 #include <cute/layout.hpp>
 
@@ -21,25 +20,6 @@ namespace tilefusion::tile_layout {
 enum class Layout { kRowMajor = 0, kColMajor = 1 };
 
 using namespace cute;
-using namespace cell;
-
-/// @brief Swizzled layout for a given Layout.
-template <const int kBitsPerAccess, typename Layout>
-struct SwizzledRowMajorLayout;
-
-template <typename Layout>
-struct SwizzledRowMajorLayout<32, Layout> {
-    static constexpr int kB = 3;
-    static constexpr int kM = 3;
-    static constexpr int kS = 3;
-
-    using SwizzledLayout = SwizzleLayout<Layout, kB, kM, kS>;
-
-    DEVICE int operator()(int i, int j) const { return swizzled_(i, j); }
-
-  private:
-    SwizzledLayout swizzled_;
-};
 
 /// @brief Swizzled layout for a single BaseTile.
 template <const int kBitsPerAccess, typename BaseShape>

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -174,7 +174,7 @@ struct SharedLayout {
 
     static constexpr Layout kType = kType_;
 
-    DEVICE int operator()(int i, int j) const {
+    HOST_DEVICE int operator()(int i, int j) const {
         int tile_x = i / BaseShape::kRows;
         int tile_y = j / BaseShape::kCols;
 

--- a/include/types/mod.hpp
+++ b/include/types/mod.hpp
@@ -9,4 +9,5 @@
 #include "types/register.hpp"
 #include "types/shared.hpp"
 #include "types/shared_tile_iterator.hpp"
+#include "types/swizzle.hpp"
 #include "types/tile_shape.hpp"

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include "cuda_utils.hpp"
@@ -18,7 +21,7 @@ struct Swizzle {
      * @param idx The index in a swizzle chunk of 2^B * 2^S * 2^M elements.
      * @return The swizzled index.
      */
-    DEVICE int apply(int idx) const {
+    HOST_DEVICE int apply(int idx) const {
         // | Bbits | Sbits | Mbits |
         // Mbits as mask for the lower bits.
         int bs = idx >> Mbits;

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -43,7 +43,7 @@ struct Swizzle {
 };
 
 /**
- * @brief Swizzle Layout.
+ * @brief Swizzled Layout.
  *
  * @tparam Layout_ The layout to swizzle.
  * @tparam kB The number of bits for B.
@@ -52,7 +52,7 @@ struct Swizzle {
  */
 template <typename Layout_, const int kB = 3, const int kM = 3,
           const int kS = 3>
-struct SwizzleLayout {
+struct SwizzledLayout {
     static constexpr int Bbits = kB;
     static constexpr int Mbits = kM;
     static constexpr int Sbits = kS;

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -5,6 +5,8 @@
 
 #include "cuda_utils.hpp"
 
+#include <cassert>
+
 namespace tilefusion::cell {
 /**
  * @brief A swizzle functor.
@@ -24,6 +26,9 @@ struct Swizzle {
     HOST_DEVICE int apply(int idx) const {
         // | Bbits | Sbits | Mbits |
         // Mbits as mask for the lower bits.
+
+        assert(idx < (1 << (Bbits + Mbits + Sbits)));
+
         int bs = idx >> Mbits;
         // (b, s) as a 2d coordinate.
         int y = bs & ((1 << Sbits) - 1);
@@ -63,6 +68,9 @@ struct SwizzleLayout {
      */
     DEVICE auto operator()(int x, int y) const {
         int idx = (x << (Mbits + Sbits)) | y;
+
+        assert(idx < (1 << (Bbits + Mbits + Sbits)));
+
         int swizzled_idx = swizzle_.apply(idx);
         int swizzled_x = swizzled_idx >> (Mbits + Sbits);
         int swizzled_y = swizzled_idx & ((1 << (Mbits + Sbits)) - 1);

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "cuda_utils.hpp"
+
+namespace tilefusion::cell {
+/**
+ * @brief A swizzle functor.
+ */
+template <const int kB, const int kM, const int kS>
+struct Swizzle {
+    static constexpr int Bbits = kB;
+    static constexpr int Mbits = kM;
+    static constexpr int Sbits = kS;
+
+    DEVICE int32 swizzle(int32 idx) const {
+        // | Bbits | Sbits | Mbits |
+        // Mbits as mask for the lower bits.
+        int32 bs = idx >> Mbits;
+        // (b, s) as a 2d coordinate.
+        int32 y = bs & ((1 << Sbits) - 1);
+        int32 x = bs >> Sbits;
+
+        int32 swizzled_y = x ^ y;
+
+        // Use swizzled_y instead of y and build swizzled idx.
+        return (x << (Mbits + Sbits)) | (swizzled_y << Mbits) |
+               (idx & ((1 << Mbits) - 1));
+    }
+};
+}  // namespace tilefusion::cell

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -66,7 +66,7 @@ struct SwizzleLayout {
      * @param x Row dimension index, with a total of 2^B rows.
      * @param y Column dimension index, with a total of 2^S * 2^M columns.
      */
-    DEVICE auto operator()(int x, int y) const {
+    HOST_DEVICE auto operator()(int x, int y) const {
         int idx = (x << (Mbits + Sbits)) | y;
 
         assert(idx < (1 << (Bbits + Mbits + Sbits)));

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -5,14 +5,20 @@
 namespace tilefusion::cell {
 /**
  * @brief A swizzle functor.
+ * A Swizzle can handle 2^B * 2^S * 2^M elements.
  */
 template <const int kB, const int kM, const int kS>
 struct Swizzle {
     static constexpr int Bbits = kB;
     static constexpr int Mbits = kM;
     static constexpr int Sbits = kS;
-
-    DEVICE int32 swizzle(int32 idx) const {
+    /**
+     * @brief Apply the swizzle to an index.
+     *
+     * @param idx The index in a swizzle chunk of 2^B * 2^S * 2^M elements.
+     * @return The swizzled index.
+     */
+    DEVICE int32 apply(int32 idx) const {
         // | Bbits | Sbits | Mbits |
         // Mbits as mask for the lower bits.
         int32 bs = idx >> Mbits;
@@ -27,4 +33,12 @@ struct Swizzle {
                (idx & ((1 << Mbits) - 1));
     }
 };
+
+template <const int kB, const int kM, const int kS>
+struct SwizzleLayout {
+    static constexpr int Bbits = kB;
+    static constexpr int Mbits = kM;
+    static constexpr int Sbits = kS;
+};
+
 }  // namespace tilefusion::cell

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -21,20 +21,35 @@ int swizzle_ref(int x, int y) {
     return swizzle_idx;
 }
 
+template <const int kB, const int kM, const int kS>
+int2 test_swizzle(int x, int y) {
+    Swizzle<kB, kM, kS> swizzle;
+    int idx = flatten(x, y, 1 << (kS + kM));
+    int swizzled_idx = swizzle.apply(idx);
+
+    int ref_swizzled_idx = swizzle_ref<kB, kM, kS>(x, y);
+
+#ifdef DEBUG
+    printf("idx: %d, swizzled_idx: %d, ref_swizzled_idx: %d\n", idx,
+           swizzled_idx, ref_swizzled_idx);
+#endif
+
+    return make_int2(swizzled_idx, ref_swizzled_idx);
+}
+
 TEST(TESTSwizzle, test_swizzle_apply) {
     const int kB = 3;
     const int kM = 3;
     const int kS = 3;
 
-    int width = 1 << (kS + kM);
-
-    Swizzle<kB, kM, kS> swizzle_3x3x3;
-
-    EXPECT_EQ((swizzle_3x3x3.apply(flatten(0, 0, width))),
-              (swizzle_ref<kB, kM, kS>(0, 0)));
-
-    EXPECT_EQ((swizzle_3x3x3.apply(flatten(1, 0, width))),
-              (swizzle_ref<kB, kM, kS>(1, 0)));
+    EXPECT_EQ((test_swizzle<kB, kM, kS>(0, 0).x),
+              (test_swizzle<kB, kM, kS>(0, 0).y));
+    EXPECT_EQ((test_swizzle<kB, kM, kS>(1, 0).x),
+              (test_swizzle<kB, kM, kS>(1, 0).y));
+    EXPECT_EQ((test_swizzle<kB, kM, kS>(1, 4).x),
+              (test_swizzle<kB, kM, kS>(1, 4).y));
+    EXPECT_EQ((test_swizzle<kB, kM, kS>(2, 0).x),
+              (test_swizzle<kB, kM, kS>(2, 0).y));
 }
 
 }  // namespace tilefusion::testing

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 #include "common/test_utils.hpp"
-#include "types/swizzle.hpp"
+#include "types/mod.hpp"
 
 namespace tilefusion::testing {
 using namespace cell;
+namespace tl = tile_layout;
 
 int flatten(int x, int y, int width) { return x * width + y; }
 
@@ -50,6 +51,27 @@ TEST(TESTSwizzle, test_swizzle_apply) {
               (test_swizzle<kB, kM, kS>(1, 4).y));
     EXPECT_EQ((test_swizzle<kB, kM, kS>(2, 0).x),
               (test_swizzle<kB, kM, kS>(2, 0).y));
+}
+
+TEST(TESTSwizzle, test_swizzle_layout) {
+    const int kB = 3;
+    const int kM = 3;
+    const int kS = 3;
+
+    const int kRows = 1 << kB;
+    const int kCols = 1 << (kM + kS);
+
+    using NaiveRowMajorLayout = tl::RowMajor<kRows, kCols>;
+    using NaiveSwizzledRowMajorLayout =
+        SwizzleLayout<NaiveRowMajorLayout, kB, kM, kS>;
+
+    NaiveSwizzledRowMajorLayout naive_row_major_swizzled_layout;
+
+    EXPECT_EQ((naive_row_major_swizzled_layout(0, 0)), 0);
+    EXPECT_EQ((naive_row_major_swizzled_layout(1, 0)), 72);
+    EXPECT_EQ((naive_row_major_swizzled_layout(1, 4)), 76);
+    EXPECT_EQ((naive_row_major_swizzled_layout(2, 0)), 144);
+    EXPECT_EQ((naive_row_major_swizzled_layout(2, 4)), 148);
 }
 
 }  // namespace tilefusion::testing

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -53,7 +53,7 @@ TEST(TESTSwizzle, test_swizzle_apply) {
               (test_swizzle<kB, kM, kS>(2, 0).y));
 }
 
-TEST(TESTSwizzle, test_swizzle_layout) {
+TEST(TESTSwizzle, test_naive_swizzle_layout) {
     const int kB = 3;
     const int kM = 3;
     const int kS = 3;
@@ -67,11 +67,35 @@ TEST(TESTSwizzle, test_swizzle_layout) {
 
     NaiveSwizzledRowMajorLayout naive_row_major_swizzled_layout;
 
-    EXPECT_EQ((naive_row_major_swizzled_layout(0, 0)), 0);
-    EXPECT_EQ((naive_row_major_swizzled_layout(1, 0)), 72);
-    EXPECT_EQ((naive_row_major_swizzled_layout(1, 4)), 76);
-    EXPECT_EQ((naive_row_major_swizzled_layout(2, 0)), 144);
-    EXPECT_EQ((naive_row_major_swizzled_layout(2, 4)), 148);
+    EXPECT_EQ((naive_row_major_swizzled_layout(0, 0)),
+              (swizzle_ref<kB, kM, kS>(0, 0)));
+    EXPECT_EQ((naive_row_major_swizzled_layout(1, 0)),
+              (swizzle_ref<kB, kM, kS>(1, 0)));
+    EXPECT_EQ((naive_row_major_swizzled_layout(1, 4)),
+              (swizzle_ref<kB, kM, kS>(1, 4)));
+    EXPECT_EQ((naive_row_major_swizzled_layout(2, 0)),
+              (swizzle_ref<kB, kM, kS>(2, 0)));
+    EXPECT_EQ((naive_row_major_swizzled_layout(2, 4)),
+              (swizzle_ref<kB, kM, kS>(2, 4)));
+}
+
+TEST(TESTSwizzle, test_nested_basetile_swizzle_layout) {
+    const int kB = 3;
+    const int kM = 3;
+    const int kS = 3;
+
+    const int kRows = 1 << kB;
+    const int kCols = 1 << (kM + kS);
+
+    using NestedBaseTileLayout =
+        tl::detail::SharedLayout<kRows, kCols, kCols, 1, tl::Layout::kRowMajor>;
+    using NestedBaseTileSwizzledLayout =
+        SwizzleLayout<NestedBaseTileLayout, kB, kM, kS>;
+
+    NestedBaseTileSwizzledLayout nested_base_tile_swizzled_layout;
+
+    EXPECT_EQ((nested_base_tile_swizzled_layout(0, 0)),
+              (swizzle_ref<kB, kM, kS>(0, 0)));
 }
 
 }  // namespace tilefusion::testing

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -43,14 +43,17 @@ TEST(TESTSwizzle, test_swizzle_apply) {
     const int kM = 3;
     const int kS = 3;
 
-    EXPECT_EQ((test_swizzle<kB, kM, kS>(0, 0).x),
-              (test_swizzle<kB, kM, kS>(0, 0).y));
-    EXPECT_EQ((test_swizzle<kB, kM, kS>(1, 0).x),
-              (test_swizzle<kB, kM, kS>(1, 0).y));
-    EXPECT_EQ((test_swizzle<kB, kM, kS>(1, 4).x),
-              (test_swizzle<kB, kM, kS>(1, 4).y));
-    EXPECT_EQ((test_swizzle<kB, kM, kS>(2, 0).x),
-              (test_swizzle<kB, kM, kS>(2, 0).y));
+    int2 swizzled_idx_0_0 = test_swizzle<kB, kM, kS>(0, 0);
+    int2 swizzled_idx_1_0 = test_swizzle<kB, kM, kS>(1, 0);
+    int2 swizzled_idx_1_4 = test_swizzle<kB, kM, kS>(1, 4);
+    int2 swizzled_idx_2_0 = test_swizzle<kB, kM, kS>(2, 0);
+    int2 swizzled_idx_2_4 = test_swizzle<kB, kM, kS>(2, 4);
+
+    EXPECT_EQ(swizzled_idx_0_0.x, swizzled_idx_0_0.y);
+    EXPECT_EQ(swizzled_idx_1_0.x, swizzled_idx_1_0.y);
+    EXPECT_EQ(swizzled_idx_1_4.x, swizzled_idx_1_4.y);
+    EXPECT_EQ(swizzled_idx_2_0.x, swizzled_idx_2_0.y);
+    EXPECT_EQ(swizzled_idx_2_4.x, swizzled_idx_2_4.y);
 }
 
 TEST(TESTSwizzle, test_naive_swizzle_layout) {
@@ -96,11 +99,11 @@ TEST(TESTSwizzle, test_nested_basetile_swizzle_layout) {
     NestedBaseTileLayout nested_base_tile_layout;
     NestedBaseTileSwizzledLayout nested_base_tile_swizzled_layout;
 
-    int idex_0_0 = nested_base_tile_layout(0, 0);
-    int idex_1_0 = nested_base_tile_layout(1, 0);
-    int idex_1_4 = nested_base_tile_layout(1, 4);
-    int idex_2_0 = nested_base_tile_layout(2, 0);
-    int idex_2_4 = nested_base_tile_layout(2, 4);
+    int idx_0_0 = nested_base_tile_layout(0, 0);
+    int idx_1_0 = nested_base_tile_layout(1, 0);
+    int idx_1_4 = nested_base_tile_layout(1, 4);
+    int idx_2_0 = nested_base_tile_layout(2, 0);
+    int idx_2_4 = nested_base_tile_layout(2, 4);
 
     int swizzled_idx_0_0 = nested_base_tile_swizzled_layout(0, 0);
     int swizzled_idx_1_0 = nested_base_tile_swizzled_layout(1, 0);
@@ -108,11 +111,13 @@ TEST(TESTSwizzle, test_nested_basetile_swizzle_layout) {
     int swizzled_idx_2_0 = nested_base_tile_swizzled_layout(2, 0);
     int swizzled_idx_2_4 = nested_base_tile_swizzled_layout(2, 4);
 
-    printf("idex_0_0: %d, swizzled_idx_0_0: %d\n", idex_0_0, swizzled_idx_0_0);
-    printf("idex_1_0: %d, swizzled_idx_1_0: %d\n", idex_1_0, swizzled_idx_1_0);
-    printf("idex_1_4: %d, swizzled_idx_1_4: %d\n", idex_1_4, swizzled_idx_1_4);
-    printf("idex_2_0: %d, swizzled_idx_2_0: %d\n", idex_2_0, swizzled_idx_2_0);
-    printf("idex_2_4: %d, swizzled_idx_2_4: %d\n", idex_2_4, swizzled_idx_2_4);
+#ifdef DEBUG
+    printf("idx_0_0: %d, swizzled_idx_0_0: %d\n", idx_0_0, swizzled_idx_0_0);
+    printf("idx_1_0: %d, swizzled_idx_1_0: %d\n", idx_1_0, swizzled_idx_1_0);
+    printf("idx_1_4: %d, swizzled_idx_1_4: %d\n", idx_1_4, swizzled_idx_1_4);
+    printf("idx_2_0: %d, swizzled_idx_2_0: %d\n", idx_2_0, swizzled_idx_2_0);
+    printf("idx_2_4: %d, swizzled_idx_2_4: %d\n", idx_2_4, swizzled_idx_2_4);
+#endif
 }
 
 }  // namespace tilefusion::testing

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -66,7 +66,7 @@ TEST(TESTSwizzle, test_naive_swizzle_layout) {
 
     using NaiveRowMajorLayout = tl::RowMajor<kRows, kCols>;
     using NaiveSwizzledRowMajorLayout =
-        SwizzleLayout<NaiveRowMajorLayout, kB, kM, kS>;
+        SwizzledLayout<NaiveRowMajorLayout, kB, kM, kS>;
 
     NaiveSwizzledRowMajorLayout naive_row_major_swizzled_layout;
 
@@ -94,7 +94,7 @@ TEST(TESTSwizzle, test_nested_basetile_swizzle_layout) {
         tl::detail::SharedLayout<kRows, kCols, kCols * 16, 16,
                                  tl::Layout::kRowMajor>;
     using NestedBaseTileSwizzledLayout =
-        SwizzleLayout<NestedBaseTileLayout, kB, kM, kS>;
+        SwizzledLayout<NestedBaseTileLayout, kB, kM, kS>;
 
     NestedBaseTileLayout nested_base_tile_layout;
     NestedBaseTileSwizzledLayout nested_base_tile_swizzled_layout;

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -88,14 +88,31 @@ TEST(TESTSwizzle, test_nested_basetile_swizzle_layout) {
     const int kCols = 1 << (kM + kS);
 
     using NestedBaseTileLayout =
-        tl::detail::SharedLayout<kRows, kCols, kCols, 1, tl::Layout::kRowMajor>;
+        tl::detail::SharedLayout<kRows, kCols, kCols * 16, 16,
+                                 tl::Layout::kRowMajor>;
     using NestedBaseTileSwizzledLayout =
         SwizzleLayout<NestedBaseTileLayout, kB, kM, kS>;
 
+    NestedBaseTileLayout nested_base_tile_layout;
     NestedBaseTileSwizzledLayout nested_base_tile_swizzled_layout;
 
-    EXPECT_EQ((nested_base_tile_swizzled_layout(0, 0)),
-              (swizzle_ref<kB, kM, kS>(0, 0)));
+    int idex_0_0 = nested_base_tile_layout(0, 0);
+    int idex_1_0 = nested_base_tile_layout(1, 0);
+    int idex_1_4 = nested_base_tile_layout(1, 4);
+    int idex_2_0 = nested_base_tile_layout(2, 0);
+    int idex_2_4 = nested_base_tile_layout(2, 4);
+
+    int swizzled_idx_0_0 = nested_base_tile_swizzled_layout(0, 0);
+    int swizzled_idx_1_0 = nested_base_tile_swizzled_layout(1, 0);
+    int swizzled_idx_1_4 = nested_base_tile_swizzled_layout(1, 4);
+    int swizzled_idx_2_0 = nested_base_tile_swizzled_layout(2, 0);
+    int swizzled_idx_2_4 = nested_base_tile_swizzled_layout(2, 4);
+
+    printf("idex_0_0: %d, swizzled_idx_0_0: %d\n", idex_0_0, swizzled_idx_0_0);
+    printf("idex_1_0: %d, swizzled_idx_1_0: %d\n", idex_1_0, swizzled_idx_1_0);
+    printf("idex_1_4: %d, swizzled_idx_1_4: %d\n", idex_1_4, swizzled_idx_1_4);
+    printf("idex_2_0: %d, swizzled_idx_2_0: %d\n", idex_2_0, swizzled_idx_2_0);
+    printf("idex_2_4: %d, swizzled_idx_2_4: %d\n", idex_2_4, swizzled_idx_2_4);
 }
 
 }  // namespace tilefusion::testing

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "common/test_utils.hpp"
+#include "types/swizzle.hpp"
+
+namespace tilefusion::testing {
+using namespace cell;
+
+int flatten(int x, int y, int width) { return x * width + y; }
+
+template <const int kB, const int kM, const int kS>
+int swizzle_ref(int x, int y) {
+    int b = x;
+    int s = y >> kM;
+
+    int swizzled_s = b ^ s;
+    int swizzle_idx =
+        (b << (kM + kS)) | (swizzled_s << kM) | (y & ((1 << kM) - 1));
+
+    return swizzle_idx;
+}
+
+TEST(TESTSwizzle, test_swizzle_apply) {
+    const int kB = 3;
+    const int kM = 3;
+    const int kS = 3;
+
+    int width = 1 << (kS + kM);
+
+    Swizzle<kB, kM, kS> swizzle_3x3x3;
+
+    EXPECT_EQ((swizzle_3x3x3.apply(flatten(0, 0, width))),
+              (swizzle_ref<kB, kM, kS>(0, 0)));
+
+    EXPECT_EQ((swizzle_3x3x3.apply(flatten(1, 0, width))),
+              (swizzle_ref<kB, kM, kS>(1, 0)));
+}
+
+}  // namespace tilefusion::testing


### PR DESCRIPTION
Based on issue #40, this PR implements a `Swizzle` functor and a `SwizzleLayout` with the following features:
- The `Swizzle` functor takes a 32-bit index and maps it to another 32-bit index through swizzling.
- The `SwizzleLayout` can transform a two-dimensional index within a given Layout into a one-dimensional index after applying the swizzle transformation.
- Tests were conducted for the `Swizzle` mapping, simple layouts, and nested layouts within the `SwizzleLayout`.

In the upcoming PRs, the implemented `Swizzle` will be used to replace the `Swizzle` and `Layout` in CUTLASS.