### PR TITLE
feat(cell): Added pretty printer for BaseTile/SharedTile/GlobalTile.

### DIFF
--- a/include/types/global.hpp
+++ b/include/types/global.hpp
@@ -9,6 +9,22 @@
 namespace tilefusion::cell {
 namespace tl = tile_layout;
 
+namespace {
+
+/// @brief Helper for pretty printing a GlobalTile's static shape-related
+///        information. This printer works ONLY on the host.
+struct GlobalTilePrettyPrinter {
+    template <typename Global>
+    static HOST void print(std::ostream& out, const Global& tile) {
+        // parameter `tile` here is not used
+        out << layout_type_to_str(Global::kType) << "(" << Global::kRows << ", "
+            << Global::kCols << ", " << Global::kRowStride << ", "
+            << Global::kColStride << "), numel = " << Global::kNumel;
+    }
+};
+
+}  // namespace
+
 template <typename Element_, typename Layout_>
 struct GlobalTile {
     using DType = Element_;
@@ -23,6 +39,10 @@ struct GlobalTile {
     static constexpr int kColStride = tl::col_stride<Layout>;
 
     static constexpr tl::Layout kType = tl::layout_type<Layout>;
+
+    // This Ctor is to enable the use of the pretty printer of SharedTile in the
+    // host code.
+    HOST GlobalTile() : data_(nullptr), layout_(Layout{}) {}
 
     DEVICE GlobalTile(DType* data) : data_(data), layout_(Layout{}) {}
 
@@ -48,4 +68,14 @@ struct GlobalTile {
     DType* data_;
     Layout layout_;
 };
+
+/// @brief Pretty printer for the static shape information of a SharedTile.
+///        Note: This printer function works ONLY on the host.
+template <typename Element, typename Layout>
+static HOST std::ostream& operator<<(std::ostream& out,
+                                     const GlobalTile<Element, Layout>& tile) {
+    GlobalTilePrettyPrinter::print(out, tile);
+    return out;
+}
+
 }  // namespace tilefusion::cell

--- a/include/types/global_tile_iterator.hpp
+++ b/include/types/global_tile_iterator.hpp
@@ -9,19 +9,21 @@
 namespace tilefusion::cell {
 namespace tl = tile_layout;
 
-namespace detail {
+namespace {
 /// @brief Helper for pretty printing a tile iterator's static shape-related
 ///        information. This printer works ONLY on the host.
 struct GTileIteratorPrettyPrinter {
     template <typename TileIterator>
     static HOST void print(std::ostream& out, const TileIterator& itr) {
-        out << "numel = " << TileIterator::Tile::kNumel << ", ChunkShape["
-            << dim_size<0, typename TileIterator::ChunkShape> << ", "
-            << dim_size<1, typename TileIterator::ChunkShape> << "], sc0 = "
-            << TileIterator::sc0 << ", sc1 = " << TileIterator::sc1;
+        size_t size1 = dim_size<0, typename TileIterator::ChunkShape>;
+        size_t size2 = dim_size<1, typename TileIterator::ChunkShape>;
+
+        out << "numel = " << TileIterator::Tile::kNumel << ", ChunkShape = ("
+            << size1 << ", " << size2 << "), stripe count = ("
+            << TileIterator::sc0 << ", " << TileIterator::sc1 << ")";
     }
 };
-}  // namespace detail
+}  // namespace
 
 /// @brief `SharedTileIterator` chunks a shared memory tile into smaller tiles
 ///         and iterates over these smaller sub-tiles.
@@ -158,7 +160,7 @@ class GTileIterator {
 template <typename TileShape, typename ChunkShape>
 static HOST std::ostream& operator<<(
     std::ostream& out, const GTileIterator<TileShape, ChunkShape>& itr) {
-    detail::GTileIteratorPrettyPrinter::print(out, itr);
+    GTileIteratorPrettyPrinter::print(out, itr);
     return out;
 }
 

--- a/include/types/shared_tile_iterator.hpp
+++ b/include/types/shared_tile_iterator.hpp
@@ -10,21 +10,21 @@
 namespace tilefusion::cell {
 namespace tl = tile_layout;
 
-using namespace cute;
-
-namespace detail {
+namespace {
 /// @brief Helper for pretty printing a tile iterator's static shape-related
 ///        information. This printer works ONLY on the host.
 struct STileIteratorPrettyPrinter {
     template <typename TileIterator>
     static HOST void print(std::ostream& out, const TileIterator& itr) {
-        out << "numel = " << TileIterator::Tile::kNumel << ", ChunkShape["
-            << dim_size<0, typename TileIterator::ChunkShape> << ", "
-            << dim_size<1, typename TileIterator::ChunkShape> << "], sc0 = "
-            << TileIterator::sc0 << ", sc1 = " << TileIterator::sc1;
+        size_t size1 = dim_size<0, typename TileIterator::ChunkShape>;
+        size_t size2 = dim_size<1, typename TileIterator::ChunkShape>;
+
+        out << "numel = " << TileIterator::Tile::kNumel << ", ChunkShape = ("
+            << size1 << ", " << size2 << "), stripe count = ("
+            << TileIterator::sc0 << ", " << TileIterator::sc1 << ")";
     }
 };
-}  // namespace detail
+}  // namespace
 
 /// @brief `SharedTileIterator` chunks a shared memory tile into smaller tiles
 ///         and iterates over these smaller sub-tiles.
@@ -136,7 +136,7 @@ class STileIterator {
 template <typename TileShape, typename ChunkShape>
 static HOST std::ostream& operator<<(
     std::ostream& out, const STileIterator<TileShape, ChunkShape>& itr) {
-    detail::STileIteratorPrettyPrinter::print(out, itr);
+    STileIteratorPrettyPrinter::print(out, itr);
     return out;
 }
 

--- a/tests/cpp/cell/test_swizzled_copy.cu
+++ b/tests/cpp/cell/test_swizzled_copy.cu
@@ -12,6 +12,8 @@
 
 #include <sstream>
 
+#define DEBUG
+
 namespace tilefusion::testing {
 using namespace cell;
 using namespace copy;
@@ -98,8 +100,8 @@ void run_test_rowmajor() {
     static_assert(kShmRows == kRows, "kShmRows must be equal to kRows");
 
     using Element = __half;
-    const int kThreads = tl::get_numel<WarpLayout> * 32;
-    static constexpr int kWarpPerRow = tl::num_rows<WarpLayout>;
+    const int kThreads = WarpLayout::kNumel * 32;
+    static constexpr int kWarpPerRow = WarpLayout::kRows;
 
     using Global = GlobalTile<Element, tl::RowMajor<kRows, kCols>>;
     using GIterator = GTileIterator<Global, TileShape<kRows, kShmCols>>;
@@ -124,12 +126,9 @@ void run_test_rowmajor() {
     LOG(INFO) << "GIterator: " << GIterator{} << std::endl
               << "SIterator1: " << SIterator1{} << std::endl
               << "SIterator2: " << SIterator2{} << std::endl
-              << "GlobalTile Shape: [" << kRows << ", " << kCols << "]"
-              << std::endl
-              << "SharedTile Shape: [" << kShmRows << ", " << kShmCols << "]"
-              << std::endl
-              << "sc0: " << kSc0 << ", sc1: " << kSc1 << std::endl
-              << "RegTile Shape: " << Reg{} << std::endl;
+              << "GlobalTile: " << Global{} << std::endl
+              << "SharedTile: " << Shared1{} << std::endl
+              << "RegTile: " << Reg{} << std::endl;
 #endif
 
     using G2S1 = GlobalToSharedLoader<Shared1, WarpLayout>;
@@ -205,16 +204,12 @@ void run_test_colmajor() {
     using Reg = RegTile<BaseTileColMajor<Element>, tl::ColMajor<kSc0, kSc1>>;
 
 #ifdef DEBUG
-    LOG(INFO) << std::endl
-              << "GIterator: " << GIterator{} << std::endl
+    LOG(INFO) << "GIterator: " << GIterator{} << std::endl
               << "SIterator1: " << SIterator1{} << std::endl
               << "SIterator2: " << SIterator2{} << std::endl
-              << "GlobalTile Shape: [" << kRows << ", " << kCols << "]"
-              << std::endl
-              << "SharedTile Shape: [" << kShmRows << ", " << kShmCols << "]"
-              << std::endl
-              << "sc0: " << kSc0 << ", sc1: " << kSc1 << std::endl
-              << "RegTile Shape: " << Reg{} << std::endl;
+              << "GlobalTile: " << Global{} << std::endl
+              << "SharedTile: " << Shared1{} << std::endl
+              << "RegTile: " << Reg{} << std::endl;
 #endif
 
     using G2S1 = GlobalToSharedLoader<Shared1, WarpLayout>;


### PR DESCRIPTION
Added pretty printers for `BaseTile`, `SharedTile`, and `GlobalTile` to display static shape and layout-related information.

For example, to use `BaseTile`, you can do the following:

```cpp
using BaseShape = WarpBaseTileShape<...>;
std::cout << BaseShape{} << std::endl;
```