### PR TITLE
fix(cell): Support different `WarpLayout` in GEMMs.

### DIFF
--- a/include/cell/copy/warp.hpp
+++ b/include/cell/copy/warp.hpp
@@ -283,10 +283,19 @@ template <typename WarpLayout_, typename BaseShape_, typename Shared_,
 struct SharedOffsetHelper<WarpLayout_, BaseShape_, Shared_, kMode_,
                           tl::Layout::kRowMajor, false> {
     DEVICE int get_warp_offset() {
-        // TODO(KuangjuX): hotfix this.
-        return warp_row_id<WarpLayout>() * kRowStride * BaseShape::kRows *
-                   Shared::kCols +
-               warp_col_id<WarpLayout>() * kColStride * BaseShape::kCols;
+        switch (kMode) {
+            case WarpReuse::kCont:
+                return warp_row_id<WarpLayout>() * kRowStride *
+                           BaseShape::kRows * Shared::kCols +
+                       warp_col_id<WarpLayout>() * kColStride *
+                           BaseShape::kCols;
+            case WarpReuse::kRowReuseCont:
+                return warp_row_id<WarpLayout>() * kRowStride *
+                       BaseShape::kRows * Shared::kCols;
+            default:
+                assert(false && "Not implemented yet.");
+                return -1;
+        }
     }
 
   private:
@@ -308,9 +317,19 @@ template <typename WarpLayout_, typename BaseShape_, typename Shared_,
 struct SharedOffsetHelper<WarpLayout_, BaseShape_, Shared_, kMode_,
                           tl::Layout::kColMajor, false> {
     DEVICE int get_warp_offset() {
-        return warp_row_id<WarpLayout>() * kRowStride * BaseShape::kRows +
-               warp_col_id<WarpLayout>() * kColStride * BaseShape::kCols *
-                   Shared::kRows;
+        switch (kMode) {
+            case WarpReuse::kCont:
+                return warp_row_id<WarpLayout>() * kRowStride *
+                           BaseShape::kRows +
+                       warp_col_id<WarpLayout>() * kColStride *
+                           BaseShape::kCols * Shared::kRows;
+            case WarpReuse::kColReuseCont:
+                return warp_col_id<WarpLayout>() * kColStride *
+                       BaseShape::kCols * Shared::kRows;
+            default:
+                assert(false && "Not implemented yet.");
+                return -1;
+        }
     }
 
   private:

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -79,7 +79,9 @@ struct SwizzledLayout<Layout_, kB, kM, kS, tl::Layout::kRowMajor> {
      */
     HOST_DEVICE auto operator()(int x, int y) const {
         int idx = (x << (Mbits + Sbits)) | y;
-        assert(idx < (1 << (Bbits + Mbits + Sbits)));
+
+        // KuangjuX: This assert may affect the performance.
+        // assert(idx < (1 << (Bbits + Mbits + Sbits)));
 
         int swizzled_idx = swizzle_(idx);
         int swizzled_x = swizzled_idx >> (Mbits + Sbits);
@@ -114,7 +116,9 @@ struct SwizzledLayout<Layout_, kB, kM, kS, tl::Layout::kColMajor> {
      */
     HOST_DEVICE auto operator()(int x, int y) const {
         int idx = (y << (Bbits + Mbits)) | x;
-        assert(idx < (1 << (Bbits + Mbits + Sbits)));
+
+        // KuanjuX: This assert may affect the performance.
+        // assert(idx < (1 << (Bbits + Mbits + Sbits)));
 
         int swizzled_idx = swizzle_(idx);
         int swizzled_y = swizzled_idx >> (Mbits + Sbits);

--- a/tests/cpp/cell/test_g2s_load.cu
+++ b/tests/cpp/cell/test_g2s_load.cu
@@ -173,6 +173,10 @@ TEST(GlobalToSharedLoad, test_row_major_load) {
     run_test_row_major<float, tl::RowMajor<4, 1>, 64, 32, true>();
     run_test_row_major<float, tl::RowMajor<2, 2>, 32, 64, true>();
     run_test_row_major<float, tl::RowMajor<2, 4>, 32, 128, true>();
+
+    // To check correctness for next tests.
+    run_test_row_major<__half, tl::RowMajor<2, 1>, 64, 64, false>();
+    run_test_row_major<__half, tl::RowMajor<2, 1>, 64, 64, true>();
 }
 
 TEST(GlobalToSharedLoad, test_col_major_load) {

--- a/tests/cpp/cell/test_gemm.cu
+++ b/tests/cpp/cell/test_gemm.cu
@@ -276,6 +276,9 @@ void run_test() {
     dim3 dim_block(config::kThreads, 1, 1);
     int shm_size = (kM + kN) * kK * sizeof(Element);
 
+    printf("config::kWarpPerRow: %d, config::kWarpPerCol: %d\n",
+           config::kWarpPerRow, config::kWarpPerCol);
+
     auto kernel = test_gemm<
         Element, ElementAcc, typename config::GlobalA, typename config::SharedA,
         typename config::LoadSharedA, typename config::GlobalB,
@@ -326,9 +329,19 @@ TEST(TestGemm, test) {
     run_test<128, 64, 64, tl::RowMajor<1, 1>, 64>();
 
     // 2 x 1 warps
-    // TODO(KuangjuX): fix different warp layout.
-    // run_test<128, 64, 128, tl::RowMajor<2, 1>, 64>();
-    // run_test<128, 128, 128, tl::RowMajor<2, 1>, 64>();
+    run_test<32, 64, 128, tl::RowMajor<2, 1>, 128>();
+    run_test<64, 64, 128, tl::RowMajor<2, 1>, 128>();
+    run_test<32, 128, 128, tl::RowMajor<2, 1>, 128>();
+
+    // 1 x 2 warps
+    run_test<32, 128, 128, tl::RowMajor<1, 2>, 128>();
+    // run_test<64, 128, 128, tl::RowMajor<1, 2>, 128>();
+
+    // 2 x 2 warps
+    run_test<64, 64, 128, tl::RowMajor<2, 2>, 128>();
+
+    // 4 x 1 warps
+    run_test<64, 16, 256, tl::RowMajor<4, 1>, 256>();
 }
 
 }  // namespace tilefusion::testing


### PR DESCRIPTION
This PR fixed some bugs and supported different `WarpLayout` in GEMMs:
- Fixed **offset recalculation** based on different `WarpReuse` mode.
- Bug fix for several corner-case scenarios.

Tips:
- GMEM -> SMEM:  Uses `kCont` `WarpReuse` for loading data.
- SMEM -> RMEM: `kRowReuse` in MatrixA and `kColReuse` in MatrixB.

For a tensor shape `[M, N, K]`:
- `M` must be multiple of `16 * kWarpRow`.
- `K` must be multiple of both `64 * kWarpCol` and `64 * kWarpRow`.
- `N` must be multiple of `16 * kWarpCol`.
