### PR TITLE
chore(csrc): Remove cutlass::half_t in favor of unified CUDA C types.

### DIFF
--- a/include/cell/compute/gemm.hpp
+++ b/include/cell/compute/gemm.hpp
@@ -85,13 +85,11 @@ struct Gemm {
 
     using BaseShape = traits::BaseTileShape<InTypeA>;
 
-    static_assert(std::is_same_v<InTypeA, cutlass::half_t> ||
-                      std::is_same_v<InTypeA, __half>,
+    static_assert(std::is_same_v<InTypeA, __half>,
                   "This GEMM implementation supports only half-precision as "
                   "the input element type.");
     static_assert(std::is_same_v<OutType, float> ||
-                      std::is_same_v<OutType, __half> ||
-                      std::is_same_v<OutType, cutlass::half_t>,
+                      std::is_same_v<OutType, __half>,
                   "The output type must be float or half.");
     static_assert(std::is_same_v<InTypeA, InTypeB>,
                   "Mismatched data type for operand A and B.");

--- a/include/cell/copy/copy_atom.hpp
+++ b/include/cell/copy/copy_atom.hpp
@@ -150,8 +150,7 @@ DEVICE void ld_shared_st_global<16>(void* dst, uint32_t src) {
 }  // namespace
 
 template <typename Element>
-    requires std::is_same_v<Element, __half> ||
-             std::is_same_v<Element, cutlass::half_t>
+    requires std::is_same_v<Element, __half>
 struct LoadMatBase {
     using DType = Element;
     using ThreadLayout = tile_layout::ColMajor<16, 2>;

--- a/include/cell/copy/vectorize.hpp
+++ b/include/cell/copy/vectorize.hpp
@@ -6,8 +6,6 @@
 #include "config.hpp"
 #include "cuda_utils.hpp"
 
-#include <cutlass/half.h>
-
 namespace tilefusion::cell::copy {
 
 /**
@@ -43,20 +41,6 @@ struct Vectorize<__half, 2> {
     static constexpr int vectorize_bits = 32;
 
     DEVICE void copy(const __half* src, __half* dst) {
-        const __half2* src_vec = reinterpret_cast<const __half2*>(src);
-        __half2* dst_vec = reinterpret_cast<__half2*>(dst);
-        *dst_vec = *src_vec;
-    }
-};
-
-template <>
-struct Vectorize<cutlass::half_t, 2> {
-    using UnVecType = cutlass::half_t;
-    using VecType = __half2;
-    static constexpr int vectorize_nums = 2;
-    static constexpr int vectorize_bits = 32;
-
-    DEVICE void copy(const cutlass::half_t* src, cutlass::half_t* dst) {
         const __half2* src_vec = reinterpret_cast<const __half2*>(src);
         __half2* dst_vec = reinterpret_cast<__half2*>(dst);
         *dst_vec = *src_vec;

--- a/include/traits/base.hpp
+++ b/include/traits/base.hpp
@@ -6,9 +6,6 @@
 #include <cuda_bf16.h>
 typedef __nv_bfloat16 __bfloat16;
 
-#include <cutlass/numeric_size.h>
-#include <cutlass/numeric_types.h>
-
 #include <type_traits>
 
 namespace tilefusion::traits {
@@ -16,9 +13,7 @@ namespace tilefusion::traits {
 template <typename Element>
 concept BaseType =
     std::is_same_v<Element, float> || std::is_same_v<Element, __half> ||
-    std::is_same_v<Element, cutlass::half_t> ||
-    std::is_same_v<Element, __bfloat16> ||
-    std::is_same_v<Element, cutlass::bfloat16_t>;
+    std::is_same_v<Element, __bfloat16>;
 
 /// @brief Architecture-specific magic numbers.
 /// @tparam Element: the data type of the elements.

--- a/include/types/packing.hpp
+++ b/include/types/packing.hpp
@@ -2,8 +2,6 @@
 
 #include "cuda_utils.hpp"
 
-#include <cutlass/numeric_types.h>
-
 namespace tilefusion::cell {
 
 template <typename DType, const int kNums>
@@ -11,13 +9,6 @@ struct Packing;
 
 template <>
 struct Packing<__half, 2> {
-    static constexpr int kDateBytes = 2;
-    static constexpr int kPackedBytes = 4;
-    using PackedType = int;
-};
-
-template <>
-struct Packing<cutlass::half_t, 2> {
     static constexpr int kDateBytes = 2;
     static constexpr int kPackedBytes = 4;
     using PackedType = int;

--- a/include/types/register.hpp
+++ b/include/types/register.hpp
@@ -20,9 +20,6 @@ constexpr int get_rows<float> = 1;
 template <>
 constexpr int get_rows<__half> = 1;
 
-template <>
-constexpr int get_rows<cutlass::half_t> = 1;
-
 template <typename DType>
 constexpr int get_cols = DType::kCols;
 
@@ -31,9 +28,6 @@ constexpr int get_cols<float> = 1;
 
 template <>
 constexpr int get_cols<__half> = 1;
-
-template <>
-constexpr int get_cols<cutlass::half_t> = 1;
 
 /// @brief Helper for pretty printing a register tile's static shape
 ///        information. This printer works ONLY on the host.

--- a/include/util/print.hpp
+++ b/include/util/print.hpp
@@ -29,21 +29,6 @@ DEVICE void print_tile(const float* data, const Layout& layout) {
 
 /// @brief Print a tile of half-precision floating point numbers.
 template <typename Layout>
-DEVICE void print_tile(const cutlass::half_t* data, const Layout& layout) {
-    const half* data_ = reinterpret_cast<const half*>(data);
-
-    for (int i = 0; i < tl::num_rows<Layout>; ++i) {
-        for (int j = 0; j < tl::num_cols<Layout>; ++j) {
-            printf("%.2f, ", __half2float(data_[layout(i, j)]));
-        }
-        printf("\n");
-
-        if (i && (i + 1) % 16 == 0) printf("\n");
-    }
-}
-
-/// @brief Print a tile of half-precision floating point numbers.
-template <typename Layout>
 DEVICE void print_tile(const __half* data, const Layout& layout) {
     for (int i = 0; i < tl::num_rows<Layout>; ++i) {
         for (int j = 0; j < tl::num_cols<Layout>; ++j) {

--- a/tests/cpp/common/test_utils.cc
+++ b/tests/cpp/common/test_utils.cc
@@ -5,28 +5,9 @@
 
 namespace tilefusion::testing {
 
-// FIXME(haruhi): A quick implementation to compare two __half arrays. Refine
-// the implementation of necessary unittest utilities.
 template <>
 void assert_equal(const __half* v1, const __half* v2, int64_t numel,
                   float epsilon) {
-    float a = 0.f;
-    float b = 0.f;
-    for (int i = 0; i < numel; ++i) {
-        a = __half2float(v1[i]);
-        b = __half2float(v2[i]);
-
-        EXPECT_NEAR(a, b, epsilon) << "v1[" << i << "] vs. v2[" << i
-                                   << "] = " << a << " vs. " << b << std::endl;
-    }
-}
-
-template <>
-void assert_equal(const cutlass::half_t* v1_, const cutlass::half_t* v2_,
-                  int64_t numel, float epsilon) {
-    const __half* v1 = reinterpret_cast<const __half*>(v1_);
-    const __half* v2 = reinterpret_cast<const __half*>(v2_);
-
     float a = 0.f;
     float b = 0.f;
     for (int i = 0; i < numel; ++i) {

--- a/tests/cpp/types/test_layout.cu
+++ b/tests/cpp/types/test_layout.cu
@@ -12,7 +12,7 @@ using namespace cell;
 namespace tl = tile_layout;
 
 TEST(TestLayout, test_layout) {
-    using Element = cutlass::half_t;
+    using Element = __half;
 
     using Layout1 = tl::RowMajor<4, 7>;
     EXPECT_EQ(tl::num_rows<Layout1>, 4);


### PR DESCRIPTION
Replace cutlass::half_t with CUDA C built-in half precision types for consistency.