### PR TITLE
refactor(cell): Uniformly support __half and bfloat16.

### DIFF
--- a/benchmarks/cpp/flashattention/main.cu
+++ b/benchmarks/cpp/flashattention/main.cu
@@ -16,8 +16,6 @@ void run(bool check = true) {
     static constexpr int kBatch = 1;
     static constexpr int kThreads = kWarpPerCol * kWarpPerRow * 32;
 
-    // static_assert(kK == kTK,
-    //               "The current implementation requires kTK == K for now.");
     static_assert(kP == kTP,
                   "The current implementation requires kTP == P for now.");
 

--- a/include/cell/copy/copy_atom.hpp
+++ b/include/cell/copy/copy_atom.hpp
@@ -150,8 +150,7 @@ DEVICE void ld_shared_st_global<16>(void* dst, uint32_t src) {
 }  // namespace
 
 template <typename Element>
-    requires std::is_same_v<Element, __half> ||
-             std::is_same_v<Element, __bfloat16>
+    requires traits::HalfType<Element>
 struct LoadMatBase {
     using DType = Element;
     using ThreadLayout = tile_layout::ColMajor<16, 2>;

--- a/include/traits/base.hpp
+++ b/include/traits/base.hpp
@@ -15,6 +15,10 @@ concept BaseType =
     std::is_same_v<Element, float> || std::is_same_v<Element, __half> ||
     std::is_same_v<Element, __bfloat16>;
 
+template <typename Element>
+concept HalfType =
+    std::is_same_v<Element, __half> || std::is_same_v<Element, __bfloat16>;
+
 /// @brief Architecture-specific magic numbers.
 /// @tparam Element: the data type of the elements.
 template <typename Element>
@@ -52,22 +56,10 @@ template <typename Element, int kBytes>
     requires BaseType<Element>
 struct SwizzleBaseTileShape;
 
-template <>
-struct SwizzleBaseTileShape<__half, 128> {
-    using DType = __half;
-
-    static constexpr int kRows = 8;
-    static constexpr int kCols = 64;
-    static constexpr int kNumel = kRows * kCols;
-
-    static constexpr int B = 3;
-    static constexpr int M = 3;
-    static constexpr int S = 3;
-};
-
-template <>
-struct SwizzleBaseTileShape<__bfloat16, 128> {
-    using DType = __bfloat16;
+template <typename Element>
+    requires HalfType<Element>
+struct SwizzleBaseTileShape<Element, 128> {
+    using DType = Element;
 
     static constexpr int kRows = 8;
     static constexpr int kCols = 64;
@@ -91,22 +83,10 @@ struct SwizzleBaseTileShape<float, 128> {
     static constexpr int S = 3;
 };
 
-template <>
-struct SwizzleBaseTileShape<__half, 64> {
-    using DType = __half;
-
-    static constexpr int kRows = 4;
-    static constexpr int kCols = 32;
-    static constexpr int kNumel = kRows * kCols;
-
-    static constexpr int B = 2;
-    static constexpr int M = 3;
-    static constexpr int S = 2;
-};
-
-template <>
-struct SwizzleBaseTileShape<__bfloat16, 64> {
-    using DType = __bfloat16;
+template <typename Element>
+    requires HalfType<Element>
+struct SwizzleBaseTileShape<Element, 64> {
+    using DType = Element;
 
     static constexpr int kRows = 4;
     static constexpr int kCols = 32;

--- a/include/types/register.hpp
+++ b/include/types/register.hpp
@@ -62,9 +62,9 @@ class RegTile {
     using DType = Element_;
     using Layout = Layout_;
 
-    static constexpr int kNumel = tl::get_numel<Layout>;
-    static constexpr int kRows = tl::num_rows<Layout>;
-    static constexpr int kCols = tl::num_cols<Layout>;
+    static constexpr int kNumel = Layout::kNumel;
+    static constexpr int kRows = Layout::kRows;
+    static constexpr int kCols = Layout::kCols;
 
     // FIXME(haruhi): this is a hack to fix the layout type deduction for when
     // the shape is 1x1. This is a workaround. Fix this to be more robust.


### PR DESCRIPTION
Introducing `HalfType`, along with `to_float` and `from_float`, enables uniform support for both bfloat16 and fp16, thereby reducing code duplication.