### PR TITLE
fix(lint): remove redundant hooks and fix math equation formatting.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-merge-conflict
     -   id: check-symlinks
     -   id: detect-private-key
-        files: (?!.*third_party)^.*$ | (?!.*book)^.*$
+        files: (?!.*3rd-party)^.*$ # ignore 3rd-party files
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-toml
@@ -18,13 +18,10 @@ repos:
     -   id: check-shebang-scripts-are-executable
     -   id: debug-statements
     -   id: mixed-line-ending
-        args: ['--fix=lf']
-        files: (?!.*third_party)^.*$ | (?!.*book)^.*$
+        args: ['--fix=lf'] # fix line endings to unix style
+        files: (?!.*3rd-party)^.*$ # ignore 3rd-party files
     -   id: check-case-conflict
     -   id: check-json
-    -   id: check-merge-conflict
-    -   id: check-shebang-scripts-are-executable
-    -   id: detect-private-key
     -   id: trailing-whitespace
 
 -   repo: https://github.com/pycqa/isort
@@ -74,11 +71,14 @@ repos:
     rev: 0.7.22
     hooks:
     -   id: mdformat
+        args: ["--number"]
         additional_dependencies:
-        -   mdformat-gfm
-        -   mdformat-frontmatter
-        -   mdformat-footnote
-        -   mdformat-tables
+          - mdformat-gfm
+          - mdformat-frontmatter
+          - mdformat-myst
+          - mdformat-tables
+          - mdformat-toc
+          - mdformat-black
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ TileFusion requires a C++20 host compiler, CUDA 12.0 or later, and GCC version 1
    make
    ```
 
-1. Run the C++ unit tests:
+2. Run the C++ unit tests:
 
    - **Run a single C++ unit test**:
      ```bash
@@ -117,13 +117,13 @@ TileFusion requires a C++20 host compiler, CUDA 12.0 or later, and GCC version 1
    python3 setup.py build bdist_wheel
    ```
 
-1. Clean the build:
+2. Clean the build:
 
    ```bash
    python3 setup.py clean
    ```
 
-1. Install the Python wrapper in editable mode (recommended for development):
+3. Install the Python wrapper in editable mode (recommended for development):
 
    ```bash
    python3 setup.py develop

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,7 +24,7 @@ cd TileFusion && git submodule update --init --recursive
    make
    ```
 
-1. Run the C++ unit tests:
+2. Run the C++ unit tests:
 
    - **Run a single C++ unit test**:
      ```bash
@@ -43,13 +43,13 @@ cd TileFusion && git submodule update --init --recursive
    python3 setup.py build bdist_wheel
    ```
 
-1. Clean the build:
+2. Clean the build:
 
    ```bash
    python3 setup.py clean
    ```
 
-1. Install the Python wrapper in editable mode (recommended for development):
+3. Install the Python wrapper in editable mode (recommended for development):
 
    ```bash
    python3 setup.py develop

--- a/docs/tiles_in_shared_memory.md
+++ b/docs/tiles_in_shared_memory.md
@@ -11,20 +11,20 @@ Let’s consider some specific examples. Suppose each thread accesses 128-bit da
 
 If the data is in ***half-precision*** floating-point format:
 
-- When the threads in a warp are arranged in a $4 \\times 8$ configuration, the `BaseTile` has dimensions of $4 \\times 64$.
-- When the threads in a warp are arranged in an $8 \\times 4$ configuration, the `BaseTile` has dimensions of $8 \\times 32$.
-- When the threads in a warp are arranged in a $16 \\times 2$ configuration, the `BaseTile` has dimensions of $16 \\times 16$.
+- When the threads in a warp are arranged in a $4 \times 8$ configuration, the `BaseTile` has dimensions of $4 \times 64$.
+- When the threads in a warp are arranged in an $8 \times 4$ configuration, the `BaseTile` has dimensions of $8 \times 32$.
+- When the threads in a warp are arranged in a $16 \times 2$ configuration, the `BaseTile` has dimensions of $16 \times 16$.
 
 Now, suppose the data is in ***single-precision*** floating-point format:
 
-- When the threads in a warp are arranged in a $4 \\times 8$ configuration, the `BaseTile` has dimensions of $4 \\times 32$.
-- When the threads in a warp are arranged in an $8 \\times 4$ configuration, the `BaseTile` has dimensions of $8 \\times 16$.
-- When the threads in a warp are arranged in a $16 \\times 2$ configuration, the `BaseTile` has dimensions of $16 \\times 8$.
+- When the threads in a warp are arranged in a $4 \times 8$ configuration, the `BaseTile` has dimensions of $4 \times 32$.
+- When the threads in a warp are arranged in an $8 \times 4$ configuration, the `BaseTile` has dimensions of $8 \times 16$.
+- When the threads in a warp are arranged in a $16 \times 2$ configuration, the `BaseTile` has dimensions of $16 \times 8$.
 
 A keen observer may notice that the largest dimension of a `BaseTile` never exceeds 1024 bits. This is not coincidental; it is a result of several hardware parameters related to global and shared memory access. Global memory traffic is routed through the data caches (the L1 and/or L2 caches). An L1 cache line is 1024 bits, which also corresponds to the maximum memory transaction size. Additionally, shared memory consists of 32 banks, each with a width of 4 bytes, collectively amounting to 1024 bits. This alignment enhances the efficiency of data transfer between global and shared memory.
 
 ## Storing Tiles in Shared Memory
 
-To ensure an efficient access pattern, we need to impose a constraint by assuming that each thread accesses 128-bit data, which is the maximum width of a vectorized access instruction. Consequently, the entire warp accesses $4 \\times 128$ bytes of data. It is known that 128 bytes is the largest transaction size. When more than 128 bytes of data per warp are loaded or stored, the GPU does not issue a single transaction but divides the data access into four transactions. Furthermore, bank conflicts occur per transaction.
+To ensure an efficient access pattern, we need to impose a constraint by assuming that each thread accesses 128-bit data, which is the maximum width of a vectorized access instruction. Consequently, the entire warp accesses $4 \times 128$ bytes of data. It is known that 128 bytes is the largest transaction size. When more than 128 bytes of data per warp are loaded or stored, the GPU does not issue a single transaction but divides the data access into four transactions. Furthermore, bank conflicts occur per transaction.
 
 Our objective is to avoid bank conflicts when loading data tiles from or storing data tiles to shared memory.

--- a/examples/cpp/02_fused_two_gemms/b2b_gemm.cu
+++ b/examples/cpp/02_fused_two_gemms/b2b_gemm.cu
@@ -52,8 +52,8 @@ void run(float epsilon = 1e-3) {
     const InType* C = thrust::raw_pointer_cast(d_c.data());
     AccType* D = thrust::raw_pointer_cast(d_d.data());
 
-    using Config =
-        B2BGemmTraits<InType, AccType, WholeShape, CtaTileShape, WarpLayout, kSharedAccess>;
+    using Config = B2BGemmTraits<InType, AccType, WholeShape, CtaTileShape,
+                                 WarpLayout, kSharedAccess>;
 
     using RegA = typename Config::RegA;
     using RegB = typename Config::RegB;

--- a/examples/cpp/02_fused_two_gemms/b2b_gemm.hpp
+++ b/examples/cpp/02_fused_two_gemms/b2b_gemm.hpp
@@ -40,7 +40,8 @@ struct B2BGemmTraits {
 
     static const bool kUseSwizzling = true;
 
-    using SharedA = SharedTile<InType, tl::RowMajor<kTM, kTK>, kUseSwizzling, kSharedAccess>;
+    using SharedA = SharedTile<InType, tl::RowMajor<kTM, kTK>, kUseSwizzling,
+                               kSharedAccess>;
 
     static constexpr int kAMs = kTM / kWarpPerRow / BaseShape::kRows;
     static constexpr int kAKs = kTK / BaseShape::kCols;
@@ -53,7 +54,8 @@ struct B2BGemmTraits {
     // operand B
     using GlobalB = GlobalTile<InType, tl::ColMajor<kK, kN>>;
     using GIteratorB = GTileIterator<GlobalB, TileShape<kTK, kTN>>;
-    using SharedB = SharedTile<InType, tl::ColMajor<kTK, kTN>, kUseSwizzling, kSharedAccess>;
+    using SharedB = SharedTile<InType, tl::ColMajor<kTK, kTN>, kUseSwizzling,
+                               kSharedAccess>;
 
     static constexpr int kBKs = kTK / BaseShape::kRows;
     static constexpr int kBNs = kTN / kWarpPerCol / BaseShape::kCols;
@@ -67,7 +69,8 @@ struct B2BGemmTraits {
     using GlobalC = GlobalTile<InType, tl::ColMajor<kN, kTP>>;
     // chunk the N dimension to fit into shared memory
     using GIteratorC = GTileIterator<GlobalC, TileShape<kTN, kTP>>;
-    using SharedC = SharedTile<InType, tl::ColMajor<kTN, kTP>, kUseSwizzling, kSharedAccess>;
+    using SharedC = SharedTile<InType, tl::ColMajor<kTN, kTP>, kUseSwizzling,
+                               kSharedAccess>;
 
     static constexpr int kCNs = kTN / BaseShape::kRows;
     static constexpr int kCPs = kTP / kWarpPerCol / BaseShape::kCols;

--- a/examples/cpp/03_flash_attention/flash_attn.cu
+++ b/examples/cpp/03_flash_attention/flash_attn.cu
@@ -4,7 +4,8 @@
 #include "flash_attn.hpp"
 #include "util.hpp"
 
-template <typename WholeShape, typename CtaTileShape, const int kBatch, const int kSharedAccess>
+template <typename WholeShape, typename CtaTileShape, const int kBatch,
+          const int kSharedAccess>
 void run(bool check = true) {
     using InType = __half;
     using AccType = float;
@@ -86,8 +87,8 @@ void run(bool check = true) {
     const InType* C = thrust::raw_pointer_cast(d_c.data());
     InType* D = thrust::raw_pointer_cast(d_d.data());
 
-    using Config =
-        FlashAttentionTraits<InType, AccType, WholeShape, CtaTileShape, kSharedAccess>;
+    using Config = FlashAttentionTraits<InType, AccType, WholeShape,
+                                        CtaTileShape, kSharedAccess>;
 
     using RegA = typename Config::RegA;
     using RegB = typename Config::RegB;

--- a/examples/cpp/03_flash_attention/flash_attn.hpp
+++ b/examples/cpp/03_flash_attention/flash_attn.hpp
@@ -43,7 +43,8 @@ struct FlashAttentionTraits {
     // chunk the K dimension to fit into shared memory
     using GIteratorA = GTileIterator<GlobalA, TileShape<kTM, kTK>>;
 
-    using SharedA = SharedTile<InType, tl::RowMajor<kTM, kTK>, true, kSharedAccess>;
+    using SharedA =
+        SharedTile<InType, tl::RowMajor<kTM, kTK>, true, kSharedAccess>;
 
     static constexpr int kAMs = kTM / kWarpPerRow / BaseShape::kRows;
     static constexpr int kAKs = kTK / BaseShape::kCols;
@@ -56,7 +57,8 @@ struct FlashAttentionTraits {
     // operand B
     using GlobalB = GlobalTile<InType, tl::ColMajor<kK, kN>>;
     using GIteratorB = GTileIterator<GlobalB, TileShape<kTK, kTN>>;
-    using SharedB = SharedTile<InType, tl::ColMajor<kTK, kTN>, true, kSharedAccess>;
+    using SharedB =
+        SharedTile<InType, tl::ColMajor<kTK, kTN>, true, kSharedAccess>;
 
     static constexpr int kBKs = kTK / BaseShape::kRows;
     static constexpr int kBNs = kTN / kWarpPerCol / BaseShape::kCols;
@@ -70,7 +72,8 @@ struct FlashAttentionTraits {
     using GlobalC = GlobalTile<InType, tl::ColMajor<kN, kTP>>;
     // chunk the N dimension to fit into shared memory
     using GIteratorC = GTileIterator<GlobalC, TileShape<kTN, kTP>>;
-    using SharedC = SharedTile<InType, tl::ColMajor<kTN, kTP>, true, kSharedAccess>;
+    using SharedC =
+        SharedTile<InType, tl::ColMajor<kTN, kTP>, true, kSharedAccess>;
 
     static constexpr int kCNs = kTN / BaseShape::kRows;
     static constexpr int kCPs = kTP / kWarpPerCol / BaseShape::kCols;


### PR DESCRIPTION
This commit improves the pre-commit configuration by:
1. Removing redundant hooks.
2. Prevents unnecessary backslash insertion in math equations.