### PR TITLE
fix(examples): Fix the complications errors.

### DIFF
--- a/examples/02_fused_two_gemms/CMakeLists.txt
+++ b/examples/02_fused_two_gemms/CMakeLists.txt
@@ -10,13 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/../../cmake")
 include(generic)
 
 list(APPEND CMAKE_PREFIX_PATH ${TORCH_CMAKE_PREFIX_PATH})
-find_package(Torch REQUIRED)
 
 set(THIRD_PARTY_DIR "${PROJECT_SOURCE_DIR}/../../3rd-party")
 include_directories(${THIRD_PARTY_DIR}/cutlass/include)
 include_directories("${PROJECT_SOURCE_DIR}/../../include")
-include_directories(${TORCH_INCLUDE_DIRS})
 
 add_executable(fused_two_consecutive_gemms fused_two_consecutive_gemms.cu)
-target_link_libraries(fused_two_consecutive_gemms ${CUDA_CUBLAS_LIBRARIES}
-                      ${TORCH_LIBRARIES})
+target_link_libraries(fused_two_consecutive_gemms ${CUDA_CUBLAS_LIBRARIES})

--- a/examples/02_fused_two_gemms/fused_two_consecutive_gemms.cu
+++ b/examples/02_fused_two_gemms/fused_two_consecutive_gemms.cu
@@ -164,7 +164,6 @@ void run(float epsilon = 1e-3) {
 }
 
 int main() {
-    // 在主函数内定义这些变量，而不是全局范围
     using WarpLayout = tl::RowMajor<2, 1>;
     static constexpr int kSharedAccess = 64;
 

--- a/examples/03_flash_attention/flash_attn_cpu.hpp
+++ b/examples/03_flash_attention/flash_attn_cpu.hpp
@@ -3,11 +3,9 @@
 
 #pragma once
 
-#include "cuda_utils.hpp"
-
 __half max(__half a, __half b) { return a > b ? a : b; }
 
-__half exp(__half x) { return __float2half(exp(__half2float(x))); }
+__half exph(__half x) { return __float2half(expf(__half2float(x))); }
 
 void host_flash_attn(int kM, int kN, int kK, int kP, int kBatch,
                      const __half* Q, const __half* K, const __half* V,
@@ -46,7 +44,7 @@ void host_flash_attn(int kM, int kN, int kK, int kP, int kBatch,
         // Broadcast sub row max to attention scores
         for (int i = 0; i < kM; ++i) {
             for (int j = 0; j < kN; ++j) {
-                acc[i * kN + j] = exp(acc[i * kN + j] - cur_row_max[i]);
+                acc[i * kN + j] = exph(acc[i * kN + j] - cur_row_max[i]);
             }
         }
 
@@ -66,10 +64,10 @@ void host_flash_attn(int kM, int kN, int kK, int kP, int kBatch,
 
         for (int i = 0; i < kM; ++i) {
             // Compute remormalization factor for the previous block.
-            prev_norm_vec[i] = exp(prev_row_max[i] - new_row_max[i]);
+            prev_norm_vec[i] = exph(prev_row_max[i] - new_row_max[i]);
 
             // Compute remormalization factor for the current block.
-            new_norm_vec[i] = exp(cur_row_max[i] - new_row_max[i]);
+            new_norm_vec[i] = exph(cur_row_max[i] - new_row_max[i]);
         }
 
         // Update normalization factor l(x).

--- a/include/kernels/flash_attn.hpp
+++ b/include/kernels/flash_attn.hpp
@@ -29,6 +29,7 @@ __global__ void ke_flash_attention(const InType* dQ, const InType* dK,
                                    int kK, int kP, int kTM, int kTN, int kTK,
                                    int kTP);
 
+// declare the host function for flash attention
 TILEFUSION_EXPORT void flash_attention(const torch::Tensor& Q,
                                        const torch::Tensor& K,
                                        const torch::Tensor& V, torch::Tensor& O,

--- a/include/kernels/fused_two_gemms.hpp
+++ b/include/kernels/fused_two_gemms.hpp
@@ -2,21 +2,21 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "cell/compute/mod.hpp"
 #include "cell/mod.hpp"
-#include "kernel_registry.hpp"
 #include "types/mod.hpp"
 
 using namespace tilefusion;
 using namespace cell;
 using namespace cell::copy;
 using namespace compute;
+
 namespace tl = tile_layout;
 
 namespace tilefusion::kernels {
 
-template <typename InType, typename AccType, typename WholeShape,
-          typename CtaTileShape, typename WarpLayout, const int kSharedAccess>
+template <typename InType, typename AccType,  //
+          typename WholeShape, typename CtaTileShape, typename WarpLayout,
+          const int kSharedAccess>
 struct FusedTwoGemmsTraits {
     using BaseShape = traits::BaseTileShape<InType>;
 
@@ -93,7 +93,6 @@ struct FusedTwoGemmsTraits {
     using RegD = RegTile<BaseTileRowMajor<AccType>, tl::RowMajor<kDMs, kDPs>>;
     using RegDHalf =
         RegTile<BaseTileRowMajor<InType>, tl::RowMajor<kDMs, kDPs>>;
-    // using DStorer = copy::RegToGlobalStorer<GlobalD, RegD, WarpLayout>;
 
     static constexpr int kAccMs = kTM / kWarpPerRow / BaseShape::kRows;
     static constexpr int kAccNs = kTN / kWarpPerCol / BaseShape::kCols;
@@ -208,9 +207,4 @@ __global__ void ke_fused_two_gemms(const InType* dA, const InType* dB,
     store_sD(sD, gD);
 }
 
-TILEFUSION_EXPORT void fused_two_gemms(const torch::Tensor& A,
-                                       const torch::Tensor& B,
-                                       const torch::Tensor& C, torch::Tensor& D,
-                                       int64_t m, int64_t n, int64_t k,
-                                       int64_t p);
 }  // namespace tilefusion::kernels

--- a/include/kernels/scatter_nd.hpp
+++ b/include/kernels/scatter_nd.hpp
@@ -33,6 +33,7 @@ __global__ void ke_scatter_nd(const T* in, T* out, const int64_t* indices,
                               unsigned int const* __restrict__ strides,
                               size_t n, size_t rank, size_t slice_size);
 
+// declare the host function for scatter_nd
 TILEFUSION_EXPORT void scatter_nd(const torch::Tensor& data,
                                   torch::Tensor& updates,
                                   const torch::Tensor& indices);

--- a/include/traits/base.hpp
+++ b/include/traits/base.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
 typedef __nv_bfloat16 __bfloat16;
 
 #include <type_traits>

--- a/src/kernels/flash_attn.cu
+++ b/src/kernels/flash_attn.cu
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "cell/compute/mod.hpp"
 #include "cell/mod.hpp"
 #include "kernels/flash_attn.hpp"
 #include "types/mod.hpp"
 
 using namespace tilefusion;
-using namespace tilefusion::cell;
-using namespace tilefusion::cell::copy;
-using namespace tilefusion::cell::compute;
+using namespace cell;
+using namespace cell::copy;
+using namespace cell::compute;
 namespace tl = tile_layout;
 
 namespace tilefusion::kernels {
@@ -251,7 +250,7 @@ __global__ void ke_flash_attention(const InType* dQ, const InType* dK,
             load_rk(sK, rK);
             __syncthreads();
 
-            compute::gemm(rQ, rK, attn_block_f32);
+            gemm(rQ, rK, attn_block_f32);
         }
         load_rv(sV, rV);
         __syncthreads();
@@ -287,7 +286,7 @@ __global__ void ke_flash_attention(const InType* dQ, const InType* dK,
         vec_add(prev_norm_mul_sum, cur_norm_mul_sum, new_sum_vec);
 
         // Compute unnormized attention block.
-        compute::gemm(attn_block, rV, exp_values_f32);
+        gemm(attn_block, rV, exp_values_f32);
 
         cast_o(exp_values_f32, exp_values);
 

--- a/src/kernels/scatter_nd.cu
+++ b/src/kernels/scatter_nd.cu
@@ -7,25 +7,7 @@
 #include <torch/script.h>
 
 namespace tilefusion::kernels {
-// reference:
-// https://github.com/InfiniTensor/RefactorGraph/blob/master/src/04kernel/cuda/src/scatter_nd.cu#L7
-// TODO: optimize the kernel by increasing the number of threads to perform
-// `atomic_add` operations under `slice_size`.
-/**
- * @brief The ScatterNdkernel updates the content of `updates` into `data` based
- * on the index information provided in the given `indices`.
- *
- * @param in The input tensor `updates`.
- * @param out The output tensor `data`.
- * @param indices The indices tensor.
- * @param strides record the stride information between different dimensions in
- * the `data` tensor.
- * @param n The number of indices.
- * @param rank The last dimension of `indices`.
- * @param slice_size The length of the slice to be updated. Specifically, it is
- * the product of the difference between the rank of `data` and the last
- * dimension of `indices` along the memory dimensions of `data`.
- */
+
 template <typename T>
 __global__ void ke_scatter_nd(const T* in, T* out, const int64_t* indices,
                               unsigned int const* __restrict__ strides,
@@ -101,7 +83,6 @@ void scatter_nd(const torch::Tensor& data, torch::Tensor& updates,
 #endif
 
     // TODO: Add some assertion checks.
-
     int64_t block = 256;
     int64_t grid = (n + block - 1) / block;
 

--- a/src/torch_bind.cc
+++ b/src/torch_bind.cc
@@ -10,7 +10,6 @@ TORCH_LIBRARY(tilefusion, m) {
 }
 
 TORCH_LIBRARY_IMPL(tilefusion, CUDA, m) {
-    // Register CUDA implementations
     KernelRegistry::instance().register_implementations(m);
 }
 


### PR DESCRIPTION
* Fixed compilation errors due to missing header file `cuda_fp16.h` in `base.hpp`.
* Fixed compilation errors causing Flash Attention in the examples directory to fail.
* Cleaned up repeated comments in `scatter_nd`.

Follow-up PRs will:

- improve the organization of kernels and their associated Python bindings to make the examples more meaningful
- address the static parameters required by the template.