### PR TITLE
fix(build): Detect PyTorch version and conditionally add ABI flag.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,9 +20,19 @@ set_target_properties(
              CUDA_RESOLVE_DEVICE_SYMBOLS ON
              CUDA_SEPARABLE_COMPILATION ON)
 
-# Refer to this issue for more context:
-# https://github.com/pytorch/pytorch/issues/13541
-target_compile_definitions(${TARGET} PUBLIC _GLIBCXX_USE_CXX11_ABI=0)
+execute_process(
+  COMMAND python -c "import torch; print(torch.__version__)"
+  OUTPUT_VARIABLE TORCH_VERSION
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(TORCH_VERSION VERSION_LESS "2.7.0")
+  message(STATUS "PyTorch version ${TORCH_VERSION} detected, using old ABI")
+  # Refer to this issue for more context:
+  # https://github.com/pytorch/pytorch/issues/13541
+  target_compile_definitions(${TARGET} PUBLIC _GLIBCXX_USE_CXX11_ABI=0)
+else()
+  message(STATUS "PyTorch version ${TORCH_VERSION} detected, using new ABI")
+endif()
 
 target_compile_options(
   ${TARGET}


### PR DESCRIPTION
When PyTorch is upgraded to version 2.7, the torch library is built with a new ABI, causing VPTQ to fail to compile successfully because it specifies the use of the old ABI. This PR detects the PyTorch version and conditionally adds the ABI flag to ensure compatibility with both older and newer versions of PyTorch.

This change prevents compilation failures when using PyTorch 2.7 while maintaining backward compatibility with earlier versions.