### PR TITLE
Refactor(layout): Introduce Block Matrix Layout for Shared Memory.

### DIFF
--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -144,7 +144,7 @@ struct BlockMatrxLayout {
     static constexpr int kRowStride = is_row_major<OuterLayout>::value
                                           ? kTileCols * kInnerNumel
                                           : kInnerNumel;
-    static constexpr int kColStride = is_row_major<InnerLayout>::value
+    static constexpr int kColStride = is_row_major<OuterLayout>::value
                                           ? kInnerNumel
                                           : kTileRows * kInnerNumel;
 
@@ -155,6 +155,15 @@ struct BlockMatrxLayout {
         const int inner_j = ColDivMod::mod(j);
 
         return outer_(outer_i, outer_j) + inner_(inner_i, inner_j);
+    }
+
+    HOST_DEVICE void dump() const {
+        for (int i = 0; i < kRows; ++i) {
+            for (int j = 0; j < kCols; ++j) {
+                printf("%d, ", operator()(i, j));
+            }
+            printf("\n");
+        }
     }
 
   private:

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -8,7 +8,6 @@
 #include "util/math_utils.hpp"
 
 #include <iostream>
-#include <type_traits>
 
 namespace tilefusion::tile_layout {
 /**

--- a/include/types/shared.hpp
+++ b/include/types/shared.hpp
@@ -21,7 +21,6 @@ struct SharedTilePrettyPrinter {
     template <typename Shared>
     static HOST void print(std::ostream& out, const Shared& tile) {
         // parameter `tile` here is not used
-
         auto swizzled = Shared::kSwizzled ? "swizzled" : "non-swizzled";
         out << "\t" << typename Shared::Layout{} << ", Swizzled = " << swizzled;
     }
@@ -36,21 +35,20 @@ class SharedTile {
     using DType = Element_;
     using Layout = Layout_;
 
-    static constexpr int kNumel = Layout::kNumel;
-
     static constexpr int kRows = Layout::kRows;
     static constexpr int kCols = Layout::kCols;
     static constexpr int kRowStride = Layout::kRowStride;
     static constexpr int kColStride = Layout::kColStride;
-    static constexpr int SwizzleBytes = SwizzleBytes_;
 
     static constexpr tl::Layout kType = Layout::kType;
+    static constexpr int kNumel = Layout::kNumel;
 
+    static constexpr bool isRowMajor = tl::is_row_major<Layout>::value;
+
+    static constexpr int SwizzleBytes = SwizzleBytes_;
     static constexpr bool kSwizzled = kSwizzled_;
 
     using SwizzleBaseShape = SwizzleBaseTileShape<DType, SwizzleBytes>;
-
-    static constexpr bool isRowMajor = (kType == tl::Layout::kRowMajor);
 
     static constexpr int kSwizzleRows =
         isRowMajor ? SwizzleBaseShape::kRows : SwizzleBaseShape::kCols;
@@ -61,9 +59,10 @@ class SharedTile {
         isRowMajor, tl::MatrixLayout<kSwizzleRows, kSwizzleCols, kRowStride, 1>,
         tl::MatrixLayout<kSwizzleRows, kSwizzleCols, 1, kColStride>>;
 
-    using Swizzled =
-        SwizzledLayout<NonSwizzled, SwizzleBaseShape::B, SwizzleBaseShape::M,
-                       SwizzleBaseShape::S, kType>;
+    using Swizzled = SwizzledLayout<
+        NonSwizzled,
+        Swizzle<SwizzleBaseShape::B, SwizzleBaseShape::M, SwizzleBaseShape::S>,
+        kType>;
 
     using InTileLayout = std::conditional_t<kSwizzled, Swizzled, NonSwizzled>;
 

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -56,28 +56,32 @@ struct Swizzle {
  *        2-D coordinate in the space defined by `Layout`.
  * @tparam Layout The `Layout` that defines a function mapping a 2-D coordinate
  *                to a 1-D index.
- * @tparam kB The number of bits for B.
- * @tparam kM The number of bits for M.
- * @tparam kS The number of bits for S.
+ * @tparam Swizzle The swizzle function.
  * @tparam kType The type of the Layout.
  */
-template <typename Layout, const int kB, const int kM, const int kS,
+template <typename Layout, typename Swizzle,
           const tl::Layout kType = Layout::kType>
 struct SwizzledLayout;
 
-template <typename Layout_, const int kB, const int kM, const int kS>
-struct SwizzledLayout<Layout_, kB, kM, kS, tl::Layout::kRowMajor> {
-    static constexpr int Bbits = kB;
-    static constexpr int Mbits = kM;
-    static constexpr int Sbits = kS;
-
+template <typename Layout_, typename Swizzle_>
+struct SwizzledLayout<Layout_, Swizzle_, tl::Layout::kRowMajor> {
     using Layout = Layout_;
-    using Swizzle = Swizzle<Bbits, Mbits, Sbits>;
+    using Swizzle = Swizzle_;
+
+    static constexpr int Bbits = Swizzle_::Bbits;
+    static constexpr int Mbits = Swizzle_::Mbits;
+    static constexpr int Sbits = Swizzle_::Sbits;
 
     static_assert(Layout::kRows == (1 << Bbits),
                   "The number of rows in the layout should be 2^B.");
     static_assert(Layout::kCols == (1 << (Mbits + Sbits)),
                   "The number of columns in the layout should be 2^S * 2^M.");
+
+    // to be compatible with all the other layouts
+    static constexpr int kRows = Layout::kRows;
+    static constexpr int kCols = Layout::kCols;
+    static constexpr int kNumel = Layout::kNumel;
+    static constexpr tl::Layout kType = Layout::kType;
 
     /**
      * @brief Compose the swizzle function with the layout function.
@@ -100,19 +104,25 @@ struct SwizzledLayout<Layout_, kB, kM, kS, tl::Layout::kRowMajor> {
     Layout layout_;
 };
 
-template <typename Layout_, const int kB, const int kM, const int kS>
-struct SwizzledLayout<Layout_, kB, kM, kS, tl::Layout::kColMajor> {
-    static constexpr int Bbits = kB;
-    static constexpr int Mbits = kM;
-    static constexpr int Sbits = kS;
-
+template <typename Layout_, typename Swizzle_>
+struct SwizzledLayout<Layout_, Swizzle_, tl::Layout::kColMajor> {
     using Layout = Layout_;
-    using Swizzle = Swizzle<Bbits, Mbits, Sbits>;
+    using Swizzle = Swizzle_;
+
+    static constexpr int Bbits = Swizzle::Bbits;
+    static constexpr int Mbits = Swizzle::Mbits;
+    static constexpr int Sbits = Swizzle::Sbits;
 
     static_assert(Layout::kRows == (1 << (Mbits + Sbits)),
                   "The number of rows in the layout should be 2^S * 2^M.");
     static_assert(Layout::kCols == (1 << Bbits),
                   "The number of columns in the layout should be 2^B.");
+
+    // to be compatible with all the other layouts
+    static constexpr int kRows = Layout::kRows;
+    static constexpr int kCols = Layout::kCols;
+    static constexpr int kNumel = Layout::kNumel;
+    static constexpr tl::Layout kType = Layout::kType;
 
     /**
      * @brief Compose the swizzle function with the layout function.

--- a/include/util/math_utils.hpp
+++ b/include/util/math_utils.hpp
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "cuda_utils.hpp"
+
+namespace tilefusion {
+
+/// @brief Helper function to check if a number is power of 2 at compile time
+template <int kN>
+consteval bool is_power_of_2() {
+    return kN > 0 && (kN & (kN - 1)) == 0;
+}
+
+/// @brief Helper function to count trailing zeros
+template <int kN>
+HOST_DEVICE constexpr int count_trailing_zeros() {
+    static_assert(is_power_of_2<kN>(), "kN must be a power of 2");
+    int count = 0;
+    int temp = kN;
+    while ((temp & 1) == 0) {
+        temp >>= 1;
+        count++;
+    }
+    return count;
+}
+
+/// @brief Helper function to compute division for power of 2
+template <int kN>
+HOST_DEVICE constexpr int div_pow2(int x) {
+    static_assert(is_power_of_2<kN>(), "kN must be a power of 2");
+    return x >> count_trailing_zeros<kN>();
+}
+
+/// @brief Helper function to compute modulo for power of 2
+template <int kN>
+HOST_DEVICE constexpr int mod_pow2(int x) {
+    static_assert(is_power_of_2<kN>(), "kN must be a power of 2");
+    return x & (kN - 1);
+}
+
+/// @brief Helper function to compute division and modulo for any number
+template <int kN>
+HOST_DEVICE constexpr int div_any(int x) {
+    return x / kN;
+}
+
+/// @brief Helper function to compute modulo for any number
+template <int kN>
+HOST_DEVICE constexpr int mod_any(int x) {
+    return x % kN;
+}
+
+/// @brief Select appropriate division/modulo functions based on whether n is
+///        power of 2
+template <bool kIsPow2, int kN>
+struct DivModSelector;
+
+template <int kN>
+struct DivModSelector<false, kN> {
+    static HOST_DEVICE constexpr int div(int x) { return div_any<kN>(x); }
+
+    static HOST_DEVICE constexpr int mod(int x) { return mod_any<kN>(x); }
+};
+
+template <int kN>
+struct DivModSelector<true, kN> {
+    static HOST_DEVICE constexpr int div(int x) { return div_pow2<kN>(x); }
+
+    static HOST_DEVICE constexpr int mod(int x) { return mod_pow2<kN>(x); }
+};
+}  // namespace tilefusion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ authors = [
 description = "TileFusion: Simplifying Kernel Fusion with Tile Processing"
 readme = "README.md"
 requires-python = ">=3.9"
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
 ]

--- a/tests/cpp/types/test_layout.cu
+++ b/tests/cpp/types/test_layout.cu
@@ -4,8 +4,6 @@
 #include "common/test_utils.hpp"
 #include "types/mod.hpp"
 
-#include <iostream>
-
 namespace tilefusion::testing {
 
 using namespace tilefusion::cell;

--- a/tests/cpp/types/test_layout.cu
+++ b/tests/cpp/types/test_layout.cu
@@ -48,15 +48,16 @@ TEST(TestLayout, test_block_row_major) {
     EXPECT_EQ(Layout::kColStride, 6);
     EXPECT_EQ(Layout::kType, tl::Layout::kRowMajor);
 
-#ifdef 0
     Layout layout;
-    for (int i = 0; i < Layout::kRows; ++i) {
-        for (int j = 0; j < Layout::kCols; ++j) {
-            std::cout << layout(i, j) << ", ";
-        }
-        std::cout << std::endl;
-    }
+
+#if defined(DEBUG)
+    layout.dump();
 #endif
+
+    EXPECT_EQ(layout(2, 0), 18);
+    EXPECT_EQ(layout(2, 1), 19);
+    EXPECT_EQ(layout(4, 3), 42);
+    EXPECT_EQ(layout(4, 4), 43);
 }
 
 TEST(TestLayout, test_block_col_major) {
@@ -68,15 +69,55 @@ TEST(TestLayout, test_block_col_major) {
     EXPECT_EQ(Layout::kColStride, 42);
     EXPECT_EQ(Layout::kType, tl::Layout::kColMajor);
 
-#ifdef 0
     Layout layout;
-    for (int i = 0; i < Layout::kRows; ++i) {
-        for (int j = 0; j < Layout::kCols; ++j) {
-            std::cout << layout(i, j) << ", ";
-        }
-        std::cout << std::endl;
-    }
+
+#if defined(DEBUG)
+    layout.dump();
 #endif
+
+    EXPECT_EQ(layout(6, 0), 18);
+    EXPECT_EQ(layout(7, 0), 19);
+    EXPECT_EQ(layout(0, 3), 42);
+    EXPECT_EQ(layout(1, 3), 43);
 }
 
+TEST(TestLayout, test_block_mixed1) {
+    using Layout = tl::BlockMixed<tl::RowMajor<14, 9>, tl::ColMajor<2, 3>>;
+
+    EXPECT_EQ(Layout::kTileRows, 7);
+    EXPECT_EQ(Layout::kTileCols, 3);
+    EXPECT_EQ(Layout::kRowStride, 18);
+    EXPECT_EQ(Layout::kColStride, 6);
+    EXPECT_EQ(Layout::kType, tl::Layout::kRowMajor);
+
+    Layout layout;
+#if defined(DEBUG)
+    layout.dump();
+#endif
+
+    EXPECT_EQ(layout(2, 0), 18);
+    EXPECT_EQ(layout(3, 0), 19);
+    EXPECT_EQ(layout(4, 3), 42);
+    EXPECT_EQ(layout(5, 3), 43);
+}
+
+TEST(TestLayout, test_block_mixed2) {
+    using Layout = tl::BlockMixed<tl::ColMajor<14, 9>, tl::RowMajor<2, 3>>;
+
+    EXPECT_EQ(Layout::kTileRows, 7);
+    EXPECT_EQ(Layout::kTileCols, 3);
+    EXPECT_EQ(Layout::kRowStride, 6);
+    EXPECT_EQ(Layout::kColStride, 42);
+    EXPECT_EQ(Layout::kType, tl::Layout::kColMajor);
+
+    Layout layout;
+#if defined(DEBUG)
+    layout.dump();
+#endif
+
+    EXPECT_EQ(layout(6, 0), 18);
+    EXPECT_EQ(layout(6, 1), 19);
+    EXPECT_EQ(layout(0, 3), 42);
+    EXPECT_EQ(layout(0, 4), 43);
+}
 }  // namespace tilefusion::testing

--- a/tests/cpp/types/test_layout.cu
+++ b/tests/cpp/types/test_layout.cu
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include "cell/copy/global_to_shared.hpp"
 #include "common/test_utils.hpp"
 #include "types/mod.hpp"
 
-#include <thrust/host_vector.h>
+#include <iostream>
 
 namespace tilefusion::testing {
-using namespace cell;
+
+using namespace tilefusion::cell;
 namespace tl = tile_layout;
 
 TEST(TestLayout, test_layout) {
@@ -37,6 +37,46 @@ TEST(TestLayout, test_layout) {
     EXPECT_EQ(type2, tl::Layout::kColMajor);
     auto layout_name2 = layout_type_to_str(type2);
     EXPECT_EQ(layout_name2, "ColMajor");
+}
+
+TEST(TestLayout, test_block_row_major) {
+    using Layout = tl::BlockRowMajor<tl::RowMajor<14, 9>, tl::RowMajor<2, 3>>;
+
+    EXPECT_EQ(Layout::kTileRows, 7);
+    EXPECT_EQ(Layout::kTileCols, 3);
+    EXPECT_EQ(Layout::kRowStride, 18);
+    EXPECT_EQ(Layout::kColStride, 6);
+    EXPECT_EQ(Layout::kType, tl::Layout::kRowMajor);
+
+#ifdef 0
+    Layout layout;
+    for (int i = 0; i < Layout::kRows; ++i) {
+        for (int j = 0; j < Layout::kCols; ++j) {
+            std::cout << layout(i, j) << ", ";
+        }
+        std::cout << std::endl;
+    }
+#endif
+}
+
+TEST(TestLayout, test_block_col_major) {
+    using Layout = tl::BlockColMajor<tl::ColMajor<14, 9>, tl::ColMajor<2, 3>>;
+
+    EXPECT_EQ(Layout::kTileRows, 7);
+    EXPECT_EQ(Layout::kTileCols, 3);
+    EXPECT_EQ(Layout::kRowStride, 6);
+    EXPECT_EQ(Layout::kColStride, 42);
+    EXPECT_EQ(Layout::kType, tl::Layout::kColMajor);
+
+#ifdef 0
+    Layout layout;
+    for (int i = 0; i < Layout::kRows; ++i) {
+        for (int j = 0; j < Layout::kCols; ++j) {
+            std::cout << layout(i, j) << ", ";
+        }
+        std::cout << std::endl;
+    }
+#endif
 }
 
 }  // namespace tilefusion::testing

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -5,9 +5,11 @@
 #include "types/mod.hpp"
 
 namespace tilefusion::testing {
+
 using namespace cell;
 namespace tl = tile_layout;
 
+namespace {
 int flatten(int x, int y, int width) { return x * width + y; }
 
 template <const int kB, const int kM, const int kS>
@@ -37,8 +39,9 @@ int2 test_swizzle(int x, int y) {
 
     return make_int2(swizzled_idx, ref_swizzled_idx);
 }
+}  // namespace
 
-TEST(TESTSwizzle, test_swizzle_apply) {
+TEST(TestSwizzle, test_swizzle_function) {
     const int kB = 3;
     const int kM = 3;
     const int kS = 3;
@@ -56,65 +59,14 @@ TEST(TESTSwizzle, test_swizzle_apply) {
     EXPECT_EQ(swizzled_idx_2_4.x, swizzled_idx_2_4.y);
 }
 
-TEST(TESTSwizzle, test_naive_swizzle_layout) {
-    const int kB = 3;
-    const int kM = 3;
-    const int kS = 3;
+TEST(TestSwizzle, test_swizzled_layout) {
+    using BlockRowMajor = tl::BlockRowMajor<
+        tl::RowMajor<16, 64>,
+        SwizzledLayout<tl::RowMajor<8, 64>, Swizzle<3, 3, 3>>>;
 
-    const int kRows = 1 << kB;
-    const int kCols = 1 << (kM + kS);
-
-    using NaiveRowMajorLayout = tl::RowMajor<kRows, kCols>;
-    using NaiveSwizzledRowMajorLayout =
-        SwizzledLayout<NaiveRowMajorLayout, kB, kM, kS, tl::Layout::kRowMajor>;
-
-    NaiveSwizzledRowMajorLayout naive_row_major_swizzled_layout;
-
-    EXPECT_EQ((naive_row_major_swizzled_layout(0, 0)),
-              (swizzle_ref<kB, kM, kS>(0, 0)));
-    EXPECT_EQ((naive_row_major_swizzled_layout(1, 0)),
-              (swizzle_ref<kB, kM, kS>(1, 0)));
-    EXPECT_EQ((naive_row_major_swizzled_layout(1, 4)),
-              (swizzle_ref<kB, kM, kS>(1, 4)));
-    EXPECT_EQ((naive_row_major_swizzled_layout(2, 0)),
-              (swizzle_ref<kB, kM, kS>(2, 0)));
-    EXPECT_EQ((naive_row_major_swizzled_layout(2, 4)),
-              (swizzle_ref<kB, kM, kS>(2, 4)));
-}
-
-TEST(TESTSwizzle, test_nested_basetile_swizzle_layout) {
-    const int kB = 3;
-    const int kM = 3;
-    const int kS = 3;
-
-    const int kRows = 1 << kB;
-    const int kCols = 1 << (kM + kS);
-
-    using NestedBaseTileLayout = tl::MatrixLayout<kRows, kCols, kCols * 16, 16>;
-    using NestedBaseTileSwizzledLayout =
-        SwizzledLayout<NestedBaseTileLayout, kB, kM, kS, tl::Layout::kRowMajor>;
-
-    NestedBaseTileLayout nested_base_tile_layout;
-    NestedBaseTileSwizzledLayout nested_base_tile_swizzled_layout;
-
-    int idx_0_0 = nested_base_tile_layout(0, 0);
-    int idx_1_0 = nested_base_tile_layout(1, 0);
-    int idx_1_4 = nested_base_tile_layout(1, 4);
-    int idx_2_0 = nested_base_tile_layout(2, 0);
-    int idx_2_4 = nested_base_tile_layout(2, 4);
-
-    int swizzled_idx_0_0 = nested_base_tile_swizzled_layout(0, 0);
-    int swizzled_idx_1_0 = nested_base_tile_swizzled_layout(1, 0);
-    int swizzled_idx_1_4 = nested_base_tile_swizzled_layout(1, 4);
-    int swizzled_idx_2_0 = nested_base_tile_swizzled_layout(2, 0);
-    int swizzled_idx_2_4 = nested_base_tile_swizzled_layout(2, 4);
-
-#ifdef DEBUG
-    printf("idx_0_0: %d, swizzled_idx_0_0: %d\n", idx_0_0, swizzled_idx_0_0);
-    printf("idx_1_0: %d, swizzled_idx_1_0: %d\n", idx_1_0, swizzled_idx_1_0);
-    printf("idx_1_4: %d, swizzled_idx_1_4: %d\n", idx_1_4, swizzled_idx_1_4);
-    printf("idx_2_0: %d, swizzled_idx_2_0: %d\n", idx_2_0, swizzled_idx_2_0);
-    printf("idx_2_4: %d, swizzled_idx_2_4: %d\n", idx_2_4, swizzled_idx_2_4);
+#if defined(DEBUG)
+    BlockRowMajor layout;
+    layout.dump();
 #endif
 }
 


### PR DESCRIPTION
This pull request addresses the issue of the shared memory layout being dispersed across internal implementations. It introduces a block matrix layout that can be combined with a swizzled layout. As a result, the entire shared memory layout can now be declared as follows: 

```cpp
using Atom = SwizzledLayout<tl::ColMajor<64, 8>, Swizzle<3, 3, 3>>;
using BlockColMajor = tl::BlockColMajor<tl::ColMajor<64, 16>, Atom>;
```

As a result, a shared memory tile is now declared as follows:

```cpp
using Shared = SharedTile<__half, BlockRowMajor>
```

Changes in this PR does not affect the existing codes. resolve https://github.com/microsoft/TileFusion/issues/52